### PR TITLE
Fix tox ci

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
       WEBHOOK_EXISTS: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read # to fetch code (actions/checkout)
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install .[ci]
       - name: Test
-        run: tox -vv
+        run: tox
         env:
           DB: sqlite
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.8'
       - uses: pre-commit/action@v3.0.0
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install .[ci]
       - name: Test
-        run: tox
+        run: tox -vv
         env:
           DB: sqlite
       - name: Upload coverage reports to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: '3.8'
       - uses: pre-commit/action@v3.0.0
 
-  test-sqlite:
+  test:
     runs-on: ubuntu-latest
     needs: lint
     strategy:
@@ -47,8 +47,6 @@ jobs:
           python -m pip install .[ci]
       - name: Test
         run: tox
-        env:
-          DB: sqlite
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python 3.8
@@ -36,7 +36,7 @@ jobs:
         python: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add more tests and example usage.
-- Extended documentation in [README](./README.md).
+- Add more tests and example usage. ([#6](https://github.com/tbrlpld/laces/pull/6))
+- Extended documentation in [README](./README.md). ([#7](https://github.com/tbrlpld/laces/pull/7))
 
 ### Changed
 
-- ...
+- Fixed tox configuration to actually run Django 3.2 in CI. Tox also uses the "testing" dependencies without the need to duplicate them in the `tox.ini`. ([#7](https://github.com/tbrlpld/laces/pull/7))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed tox configuration to actually run Django 3.2 in CI. Tox also uses the "testing" dependencies without the need to duplicate them in the `tox.ini`. ([#10](https://github.com/tbrlpld/laces/pull/10))
-- Bumped GitHub Actions to latest versions. This removes a reliance on the now deprecated Node 16. ([#11](https://github.com/tbrlpld/laces/pull/11))
+- Bumped GitHub Actions to latest versions. This removes a reliance on the now deprecated Node 16. ([#10](https://github.com/tbrlpld/laces/pull/10))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fixed tox configuration to actually run Django 3.2 in CI. Tox also uses the "testing" dependencies without the need to duplicate them in the `tox.ini`. ([#7](https://github.com/tbrlpld/laces/pull/7))
+- Bumped GitHub Actions to latest versions. This removes a reliance on the now deprecated Node 16. ([#11](https://github.com/tbrlpld/laces/pull/11))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# laces Changelog
+# Laces Changelog
 
 All notable changes to this project will be documented in this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add more tests and example usage.
+- Extended documentation in [README](./README.md).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fixed tox configuration to actually run Django 3.2 in CI. Tox also uses the "testing" dependencies without the need to duplicate them in the `tox.ini`. ([#7](https://github.com/tbrlpld/laces/pull/7))
+- Fixed tox configuration to actually run Django 3.2 in CI. Tox also uses the "testing" dependencies without the need to duplicate them in the `tox.ini`. ([#10](https://github.com/tbrlpld/laces/pull/10))
 - Bumped GitHub Actions to latest versions. This removes a reliance on the now deprecated Node 16. ([#11](https://github.com/tbrlpld/laces/pull/11))
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add more tests and example usage. ([#6](https://github.com/tbrlpld/laces/pull/6))
-- Extended documentation in [README](./README.md). ([#7](https://github.com/tbrlpld/laces/pull/7))
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ testing = [
     "coverage==7.3.4",
 ]
 ci = [
-    "tox==4.11.3",
-    "tox-gh-actions==3.1.3",
+    "tox==4.12.1",
+    "tox-gh-actions==3.2.0",
     # Allow use of pyenv for virtual environments. To enable you need to set `VIRTUALENV_DISCOVERY=pyenv` in the shell.
     # This is useful to help tox find the correct python version when using pyenv.
     "virtualenv-pyenv==0.4.0"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,4 @@
 [tox]
-;skipsdist = True
-;usedevelop = True
-
 envlist =
     python{3.8,3.9,3.10,3.11}-django{3.2,4.1,4.2}
 
@@ -17,7 +14,6 @@ DB =
     sqlite: sqlite
 
 [testenv]
-;install_command = python -m pip install -e ".[testing]" -U {opts} {packages}
 package = editable
 extras = testing
 
@@ -29,6 +25,7 @@ commands =
     # Run coverage in append mode so that we get a combined report over all environments.
     # This can not be combined with parallel mode.
     # This only affects local working, because each env is run on a different runner in CI.
+    # In CI, Codecov will combine the reports.
     coverage run -a testmanage.py test --deprecation all {posargs: -v 2}
 
 commands_post =
@@ -42,9 +39,6 @@ basepython =
     python3.11: python3.11
 
 deps =
-;    # Coverage is required here (even though it's in pyproject.toml) to make it work on GitHub Actions
-;    coverage
-;
     django3.2: Django>=3.2,<4.0
     django4.0: Django>=4.0,<4.1
     django4.1: Django>=4.1,<4.2

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,6 @@ python =
     3.10: python3.10
     3.11: python3.11
 
-[gh-actions:env]
-DB =
-    sqlite: sqlite
-
 [testenv]
 package = editable
 extras = testing

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-skipsdist = True
-usedevelop = True
+;skipsdist = True
+;usedevelop = True
 
 envlist =
     python{3.8,3.9,3.10,3.11}-django{3.2,4.1,4.2}
@@ -17,7 +17,9 @@ DB =
     sqlite: sqlite
 
 [testenv]
-install_command = python -m pip install -e ".[testing]" -U {opts} {packages}
+;install_command = python -m pip install -e ".[testing]" -U {opts} {packages}
+package = editable
+extras = testing
 
 commands_pre =
     # Mostly to check that the requirements are in order

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,7 @@
 [tox]
+skipsdist = True
+usedevelop = True
+
 envlist =
     python{3.8,3.9,3.10,3.11}-django{3.2,4.1,4.2}
 
@@ -10,8 +13,9 @@ python =
     3.11: python3.11
 
 [testenv]
-package = editable
-extras = testing
+;package = editable
+;extras = testing
+install_command = python -m pip install -e ".[testing]" {opts} {packages}
 
 commands_pre =
     # Mostly to check that the requirements are in order

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,12 @@ DB =
     sqlite: sqlite
 
 [testenv]
-install_command = pip install -e ".[testing]" -U {opts} {packages}
+install_command = python -m pip install -e ".[testing]" -U {opts} {packages}
+
+commands_pre =
+    # Mostly to check that the requirements are in order
+    python -m pip freeze
+
 commands =
     # Run coverage in append mode so that we get a combined report over all environments.
     # This can not be combined with parallel mode.
@@ -35,9 +40,9 @@ basepython =
     python3.11: python3.11
 
 deps =
-    # Coverage is required here (even though it's in pyproject.toml) to make it work on GitHub Actions
-    coverage
-
+;    # Coverage is required here (even though it's in pyproject.toml) to make it work on GitHub Actions
+;    coverage
+;
     django3.2: Django>=3.2,<4.0
     django4.0: Django>=4.0,<4.1
     django4.1: Django>=4.1,<4.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,4 @@
 [tox]
-skipsdist = True
-usedevelop = True
-
 envlist =
     python{3.8,3.9,3.10,3.11}-django{3.2,4.1,4.2}
 
@@ -13,9 +10,8 @@ python =
     3.11: python3.11
 
 [testenv]
-;package = editable
-;extras = testing
-install_command = python -m pip install -e ".[testing]" {opts} {packages}
+package = editable
+extras = testing
 
 commands_pre =
     # Mostly to check that the requirements are in order


### PR DESCRIPTION
This PR fixes the tox configuration in CI. 

The `gh-actions:env` section was not needed. It actually led to not all environment combinations being run and it also meant that the dependency installation did not happen in the expected environments. 

See: https://github.com/ymyzk/tox-gh-actions/discussions/193

One symptom of the above was the we never actually tested with Django 3.2 in CI (which was noticed because it led to errors when running tox locally, where the environments were working just fine). Now we are properly testing Django 3.2 on CI as well. 

Another symptom of the above was that we needed to redefine `coverage` in the `tox.ini` dependencies although it is already listed in the `testing` dependencies in `pyproject.toml`. 

The redefinition of `coverage` was also solved (before the above complete solution to the environment issue) previously by switching from `skipsdist`, `usedevelop` and a custom `install_command` to the more modern tox config options `extras = testing` and `package = editable`. 



Also bumps CI versions to not use deprecated Node version 16 anymore.
