### PR TITLE
Fix context assertions

### DIFF
--- a/laces/test/example/templates/pages/kitchen-sink.html
+++ b/laces/test/example/templates/pages/kitchen-sink.html
@@ -11,13 +11,22 @@
     {% component passes_instance_attr_name %}
     {% component passes_self %}
     {% component dataclass_attr_name %}
+
+    {% comment %}
+        The component output the name received from the parent context.
+        The parent context should already have a `name` variable defined.
+        That defined variable is used in the first case.
+        In the other cases, we override what's directly available in the parent context by using the features of the template tag.
+    {% endcomment %}
     {% component passes_name_from_parent_context %}
-    {% with name="Erin" %}
-        {% comment %}
-            Override parent context through the with-block. The same component receives a different parent context.
-        {% endcomment %}
+    {% component passes_name_from_parent_context with name="Erin Keyword" %}
+    {% with name="Erin Block" %}
         {% component passes_name_from_parent_context %}
     {% endwith %}
+    {% with name="Erin Block" %}
+        {% component passes_name_from_parent_context with name="Erin Keyword over Block" %}
+    {% endwith %}
+
     {% component section_with_heading_and_paragraph %}
     {% component list_section %}
 </body>

--- a/laces/test/example/templates/pages/tag-examples.html
+++ b/laces/test/example/templates/pages/tag-examples.html
@@ -1,0 +1,13 @@
+{% load laces %}
+<html>
+<body>
+    {% component my_component %}
+    {% component my_component with name="Keyword" %}
+    {% with name="Block" %}
+        {% component my_component  %}
+    {% endwith %}
+    {% with name="Block" %}
+        {% component my_component with name="Keyword over block"  %}
+    {% endwith %}
+</body>
+</html>

--- a/laces/test/tests/test_views.py
+++ b/laces/test/tests/test_views.py
@@ -1,4 +1,5 @@
 """Tests for the example views that demonstrate the use of components."""
+
 from http import HTTPStatus
 
 from django.test import RequestFactory, TestCase
@@ -22,7 +23,9 @@ class TestKitchenSink(TestCase):
         self.assertInHTML("<h1>Hello Carol's self</h1>", response_html)
         self.assertInHTML("<h1>Hello Charlie</h1>", response_html)
         self.assertInHTML("<h1>Hello Dan</h1>", response_html)
-        self.assertInHTML("<h1>Hello Erin</h1>", response_html)
+        self.assertInHTML("<h1>Hello Erin Keyword</h1>", response_html)
+        self.assertInHTML("<h1>Hello Erin Block</h1>", response_html)
+        self.assertInHTML("<h1>Hello Erin Keyword over Block</h1>", response_html)
         self.assertInHTML(
             """
             <section>

--- a/laces/tests/test_templatetags/test_laces.py
+++ b/laces/tests/test_templatetags/test_laces.py
@@ -1,8 +1,9 @@
 import os
 import random
 
+from copy import deepcopy
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 from django.conf import settings
 from django.template import Context, Template, TemplateSyntaxError
@@ -10,6 +11,30 @@ from django.test import SimpleTestCase
 from django.utils.html import format_html
 
 from laces.components import Component
+
+
+class CopyingMock(MagicMock):
+    """
+    A mock that stores copies of the call arguments.
+
+    The default behaviour of a mock is to store references to the call arguments. This
+    means that if the call arguments are mutable, then the stored call arguments will
+    change when the call arguments are changed. This is not always desirable. E.g. the
+    `django.template.Context` class is mutable and the different layers are popped off
+    the context during rendering. This makes it hard to inspect the context that was
+    passed to a mock.
+
+    This variant of the mock stores copies of the call arguments. This means that the
+    stored call arguments will not change when the actual call arguments are changed.
+
+    This override is based on the Python docs:
+    https://docs.python.org/3/library/unittest.mock-examples.html#coping-with-mutable-arguments  # noqa: E501
+    """
+
+    def __call__(self, /, *args, **kwargs):
+        args = deepcopy(args)
+        kwargs = deepcopy(kwargs)
+        return super().__call__(*args, **kwargs)
 
 
 class TestComponentTag(SimpleTestCase):
@@ -28,7 +53,7 @@ class TestComponentTag(SimpleTestCase):
 
         self.component = ExampleComponent()
         # Using a mock to be able to check if the `render_html` method is called.
-        self.component.render_html = Mock(return_value="Rendered HTML")
+        self.component.render_html = CopyingMock(return_value="Rendered HTML")
 
     def set_parent_template(self, template_string):
         template_string = "{% load laces %}" + template_string
@@ -37,8 +62,26 @@ class TestComponentTag(SimpleTestCase):
     def render_parent_template_with_context(self, context: dict):
         return self.parent_template.render(Context(context))
 
-    def assertRenderHTMLCalledWith(self, context: dict):
-        self.component.render_html.assert_called_with(Context(context))
+    def assertVariablesAvailableInRenderHTMLParentContext(
+        self,
+        expected_context_variables: dict,
+    ):
+        """
+        Assert that the variables defined in the given dictionary are available in the
+        parent context of the `render_html` method.
+
+        Keys and values are checked.
+        """
+        actual_context = self.component.render_html.call_args.args[0]
+
+        for key, value in expected_context_variables.items():
+            self.assertIn(key, actual_context)
+            actual_value = actual_context[key]
+            if not isinstance(actual_value, Component):
+                # Because we are inspecting copies of the context variables, we can
+                # not easily compare the components by identity. For now, we just
+                # skip components.
+                self.assertEqual(actual_value, value)
 
     def test_render_html_return_in_parent_template(self):
         self.assertEqual(self.component.render_html(), "Rendered HTML")
@@ -105,8 +148,9 @@ class TestComponentTag(SimpleTestCase):
 
         self.render_parent_template_with_context({"my_component": self.component})
 
-        self.assertTrue(self.component.render_html.called)
-        self.assertRenderHTMLCalledWith({"my_component": self.component})
+        self.assertVariablesAvailableInRenderHTMLParentContext(
+            {"my_component": self.component}
+        )
 
     def test_render_html_parent_context_when_other_variable_in_context(self):
         self.set_parent_template("{% component my_component %}")
@@ -118,21 +162,23 @@ class TestComponentTag(SimpleTestCase):
             }
         )
 
-        self.assertRenderHTMLCalledWith(
+        self.assertVariablesAvailableInRenderHTMLParentContext(
             {
                 "my_component": self.component,
                 "test": "something",
             }
         )
 
-    def test_render_html_parent_context_when_with_block_sets_extra_context(self):
+    def test_render_html_parent_context_when_with_block_sets_extra_context(
+        self,
+    ):
         self.set_parent_template(
             "{% with test='something' %}{% component my_component %}{% endwith %}"
         )
 
         self.render_parent_template_with_context({"my_component": self.component})
 
-        self.assertRenderHTMLCalledWith(
+        self.assertVariablesAvailableInRenderHTMLParentContext(
             {
                 "my_component": self.component,
                 "test": "something",
@@ -144,7 +190,7 @@ class TestComponentTag(SimpleTestCase):
 
         self.render_parent_template_with_context({"my_component": self.component})
 
-        self.assertRenderHTMLCalledWith(
+        self.assertVariablesAvailableInRenderHTMLParentContext(
             {
                 "my_component": self.component,
                 "test": "something",
@@ -169,7 +215,7 @@ class TestComponentTag(SimpleTestCase):
         # are not included in the context that is passed to the `render_html` method.
         # The `test` variable, that was defined with the with-keyword, is present
         # though. Both of these effects come form the `only` keyword.
-        self.assertRenderHTMLCalledWith({"test": "nothing else"})
+        self.assertVariablesAvailableInRenderHTMLParentContext({"test": "nothing else"})
 
     def test_render_html_parent_context_when_with_block_overrides_context(self):
         self.set_parent_template(
@@ -183,7 +229,7 @@ class TestComponentTag(SimpleTestCase):
             }
         )
 
-        self.assertRenderHTMLCalledWith(
+        self.assertVariablesAvailableInRenderHTMLParentContext(
             {
                 "my_component": self.component,
                 # The `test` variable is overriden by the `with` block.
@@ -203,7 +249,7 @@ class TestComponentTag(SimpleTestCase):
             }
         )
 
-        self.assertRenderHTMLCalledWith(
+        self.assertVariablesAvailableInRenderHTMLParentContext(
             {
                 "my_component": self.component,
                 # The `test` variable is overriden by the `with` keyword.
@@ -222,7 +268,7 @@ class TestComponentTag(SimpleTestCase):
 
         self.render_parent_template_with_context({"my_component": self.component})
 
-        self.assertRenderHTMLCalledWith(
+        self.assertVariablesAvailableInRenderHTMLParentContext(
             {
                 "my_component": self.component,
                 "test": "something else",

--- a/laces/tests/test_templatetags/test_laces.py
+++ b/laces/tests/test_templatetags/test_laces.py
@@ -28,7 +28,7 @@ class TestComponentTag(SimpleTestCase):
 
         self.component = ExampleComponent()
         # Using a mock to be able to check if the `render_html` method is called.
-        self.component.render_html: Mock = Mock(return_value="Rendered HTML")
+        self.component.render_html = Mock(return_value="Rendered HTML")
 
     def set_parent_template(self, template_string):
         template_string = "{% load laces %}" + template_string
@@ -38,7 +38,7 @@ class TestComponentTag(SimpleTestCase):
         return self.parent_template.render(Context(context))
 
     def assertRenderHTMLCalledWith(self, context: dict):
-        self.assertTrue(self.component.render_html.called_with(Context(context)))
+        self.component.render_html.assert_called_with(Context(context))
 
     def test_render_html_return_in_parent_template(self):
         self.assertEqual(self.component.render_html(), "Rendered HTML")

--- a/laces/tests/test_templatetags/test_laces.py
+++ b/laces/tests/test_templatetags/test_laces.py
@@ -106,9 +106,7 @@ class TestComponentTag(SimpleTestCase):
         self.render_parent_template_with_context({"my_component": self.component})
 
         self.assertTrue(self.component.render_html.called)
-        # The component itself is not included in the context that is passed to the
-        # `render_html` method.
-        self.assertRenderHTMLCalledWith({})
+        self.assertRenderHTMLCalledWith({"my_component": self.component})
 
     def test_render_html_parent_context_when_other_variable_in_context(self):
         self.set_parent_template("{% component my_component %}")
@@ -120,7 +118,12 @@ class TestComponentTag(SimpleTestCase):
             }
         )
 
-        self.assertRenderHTMLCalledWith({"test": "something"})
+        self.assertRenderHTMLCalledWith(
+            {
+                "my_component": self.component,
+                "test": "something",
+            }
+        )
 
     def test_render_html_parent_context_when_with_block_sets_extra_context(self):
         self.set_parent_template(
@@ -129,14 +132,24 @@ class TestComponentTag(SimpleTestCase):
 
         self.render_parent_template_with_context({"my_component": self.component})
 
-        self.assertRenderHTMLCalledWith({"test": "something"})
+        self.assertRenderHTMLCalledWith(
+            {
+                "my_component": self.component,
+                "test": "something",
+            }
+        )
 
     def test_render_html_parent_context_when_with_keyword_sets_extra_context(self):
         self.set_parent_template("{% component my_component with test='something' %}")
 
         self.render_parent_template_with_context({"my_component": self.component})
 
-        self.assertRenderHTMLCalledWith({"test": "something"})
+        self.assertRenderHTMLCalledWith(
+            {
+                "my_component": self.component,
+                "test": "something",
+            }
+        )
 
     def test_render_html_parent_context_when_with_only_keyword_limits_extra_context(
         self,
@@ -152,10 +165,10 @@ class TestComponentTag(SimpleTestCase):
             }
         )
 
-        # The `other` variable from the parent's rendering context is not included in
-        # the context that is passed to the `render_html` method. The `test` variable,
-        # that was defined with the with-keyword, is present though. Both of these
-        # effects come form the `only` keyword.
+        # The `my_component` and `other` variables from the parent's rendering context
+        # are not included in the context that is passed to the `render_html` method.
+        # The `test` variable, that was defined with the with-keyword, is present
+        # though. Both of these effects come form the `only` keyword.
         self.assertRenderHTMLCalledWith({"test": "nothing else"})
 
     def test_render_html_parent_context_when_with_block_overrides_context(self):
@@ -170,7 +183,13 @@ class TestComponentTag(SimpleTestCase):
             }
         )
 
-        self.assertRenderHTMLCalledWith({"test": "something else"})
+        self.assertRenderHTMLCalledWith(
+            {
+                "my_component": self.component,
+                # The `test` variable is overriden by the `with` block.
+                "test": "something else",
+            }
+        )
 
     def test_render_html_parent_context_when_with_keyword_overrides_context(self):
         self.set_parent_template(
@@ -184,7 +203,13 @@ class TestComponentTag(SimpleTestCase):
             }
         )
 
-        self.assertRenderHTMLCalledWith({"test": "something else"})
+        self.assertRenderHTMLCalledWith(
+            {
+                "my_component": self.component,
+                # The `test` variable is overriden by the `with` keyword.
+                "test": "something else",
+            },
+        )
 
     def test_render_html_parent_context_when_with_keyword_overrides_with_block(self):
         self.set_parent_template(
@@ -197,7 +222,12 @@ class TestComponentTag(SimpleTestCase):
 
         self.render_parent_template_with_context({"my_component": self.component})
 
-        self.assertRenderHTMLCalledWith({"test": "something else"})
+        self.assertRenderHTMLCalledWith(
+            {
+                "my_component": self.component,
+                "test": "something else",
+            }
+        )
 
     def test_fallback_render_method_arg_true_and_object_with_render_method(self):
         # -----------------------------------------------------------------------------


### PR DESCRIPTION
Previously, I was using `Mock.called_with()` to check the context object that the `Components.render_html()` method was called with by the `{% component %}` template tag. 

It turns out: that method does not exist at all! I don't know why I thought it did (I feel inclined to blame Copilot for adding it and myself for not confirming). The issue is that I replaces `render_html` with a mock, and mocks will return other mocks when any name on them is called. 

So the final assertion I was using 
```python
self.assertTrue(self.component.render_html.called_with(Context(context)))
```
always passed. 

I must have committed the cardinal sin and never confirmed my tests are actually checking what I think they do by failing them on purpose.

Up-on investigation, I found that the real method to check a mocks call arguments is [`Mock.assert_called_with()`](https://docs.python.org/3.12/library/unittest.mock.html#unittest.mock.Mock.assert_called_with) or you can directly inspect the [`Mock.call_args`](https://docs.python.org/3.12/library/unittest.mock.html#unittest.mock.Mock.call_args) property.

However, because the `Context` object is complex to set up, so we could not just create a new `Context` from a `dict`. We would have to recreate all the layers that the Context goes through to make the context objects comparable.

Thus, it seemed more desirable to compare the effective context by checking the keys and values.

However, this also ran into issues. The context object is mutable and values / layers are bing popped off as rendering happens. So, to be able to inspect the context as it was at the time of being passed to the `render_html` method, we need a special custom Mock subclass that stores copies of the values.

On top of all that, it also revealed that I was even asserting the wrong data. For some reason, none of my assertions assumed that the component itself would be in the parent context. But it definitely is. And that makes total sense too. We would need special behavior to exclude it. But we don't have that and it's probably better that way. So the actual assertions are updated too.
