### PR TITLE
Pre commit tools as normal dependencies

### DIFF
--- a/.github/scripts/report_nightly_build_failure.py
+++ b/.github/scripts/report_nightly_build_failure.py
@@ -3,6 +3,7 @@ Called by GH Actions when the nightly build fails.
 
 This reports an error to the #nightly-build-failures Slack channel.
 """
+
 import os
 
 import requests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.8
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.11'
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install .[dev]
       - uses: pre-commit/action@v3.0.0
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install .[ci]
+          python -m pip install .[dev]
       - name: Test
         run: tox
       - name: Upload coverage reports to Codecov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,16 +32,14 @@ repos:
         language: system
         types: [python]
         files: \.(py)$
+      - id: flake8
+        name: flake8
+        entry: flake8
+        language: system
+        types: [python]
+        files: \.(py)$
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==23.9.1]
-  - repo: https://github.com/pycqa/flake8
-    # flake8 config is in setup.cfg
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-bugbear
-          - flake8-comprehensions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,12 +18,14 @@ repos:
         args: ['--unsafe']
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 23.9.1
+  - repo: local
     hooks:
       - id: black
-        language_version: python3
-        args: ['--target-version', 'py38']
+        name: black
+        entry: black
+        language: system
+        types: [python]
+        files: \.(py)$
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,16 +26,17 @@ repos:
         language: system
         types: [python]
         files: \.(py)$
+      - id: isort
+        name: isort
+        entry: isort
+        language: system
+        types: [python]
+        files: \.(py)$
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==23.9.1]
-  - repo: https://github.com/pycqa/isort
-    # isort config is in setup.cfg
-    rev: 5.12.0
-    hooks:
-      - id: isort
   - repo: https://github.com/pycqa/flake8
     # flake8 config is in setup.cfg
     rev: 6.1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,19 +25,16 @@ repos:
         entry: black
         language: system
         types: [python]
-        files: \.(py)$
       - id: isort
         name: isort
         entry: isort
         language: system
         types: [python]
-        files: \.(py)$
       - id: flake8
         name: flake8
         entry: flake8
         language: system
         types: [python]
-        files: \.(py)$
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,11 @@ repos:
         entry: black
         language: system
         types: [python]
+      - id: blacken-docs
+        name: blacken-docs
+        entry: blacken-docs
+        language: system
+        files: '\.(rst|md|markdown|py|tex)$'
       - id: isort
         name: isort
         entry: isort
@@ -35,8 +40,3 @@ repos:
         entry: flake8
         language: system
         types: [python]
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.16.0
-    hooks:
-      - id: blacken-docs
-        additional_dependencies: [black==23.9.1]

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ With your preferred virtualenv activated, install testing dependencies:
 
 ```sh
 $ python -m pip install --upgrade pip>=21.3
-$ python -m pip install -e '.[testing]' -U
+$ python -m pip install -e '.[dev]' -U
 ```
 
 #### Using flit
@@ -340,22 +340,41 @@ You can now visit `http://localhost:8020/`.
 
 #### Testing with coverage
 
-To run tests with coverage, use:
+`tox` is configured to run tests with coverage.
+The coverage report is combined for all environments.
+This is done by using the `--append` flag when running coverage in `tox`.
+This means it will also include previous results.
 
-```sh
-$ coverage run ./testmanage.py test
-```
-
-Then see the results with
+You can see the coverage report by running:
 
 ```sh
 $ coverage report
 ```
 
-When the tests are run with `tox`, the coverage report is combined for all environments.
-This is done by using the `--append` flag when running coverage in `tox`.
-This means it will also include previous results.
 To get a clean report, you can run `coverage erase` before running `tox`.
+
+#### Running tests without tox
+
+If you want to run tests without `tox`, you can use the `testmanage.py` script.
+This script is a wrapper around Django's `manage.py` and will run tests with the correct settings.
+
+To make this work, you need to have the `testing` dependencies installed.
+
+```sh
+$ python -m pip install -e '.[testing]' -U
+```
+
+Then you can run tests with:
+
+```sh
+$ ./testmanage.py test
+````
+
+To run tests with coverage, use:
+
+```sh
+$ coverage run ./testmanage.py test
+```
 
 ### Python version management
 

--- a/laces/test/example/components.py
+++ b/laces/test/example/components.py
@@ -4,6 +4,7 @@ Examples of how components might be defined.
 This is unlikely to be an exhaustive list of examples, but it should be enough to
 demonstrate the basic concepts of how components work.
 """
+
 from dataclasses import asdict, dataclass
 
 from django.utils.html import format_html

--- a/laces/test/tests/test_components.py
+++ b/laces/test/tests/test_components.py
@@ -4,6 +4,7 @@ Tests for the example components.
 These tests are very basic and only ensure that the examples are configured as
 desired. More thorough tests can be found in the `laces.tests.test_components` module.
 """
+
 from django.test import SimpleTestCase
 
 from laces.test.example.components import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     # Linting etc.
     "pre-commit==3.4.0",
     "black==24.1.1",
+    "blacken-docs==1.16.0",
     "isort==5.13.2",
     "flake8==7.0.0",
     "flake8-bugbear",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     # Linting etc.
     "pre-commit==3.4.0",
     "black==24.1.1",
+    "isort==5.13.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ dev = [
     "pre-commit==3.4.0",
     "black==24.1.1",
     "isort==5.13.2",
+    "flake8==7.0.0",
+    "flake8-bugbear",
+    "flake8-comprehensions",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,15 +35,20 @@ dependencies = [
 [project.optional-dependencies]
 testing = [
     "dj-database-url==2.1.0",
-    "pre-commit==3.4.0",
+    # Running tests with coverage inside the tox test environment.
     "coverage==7.3.4",
 ]
-ci = [
+dev = [
     "tox==4.12.1",
     "tox-gh-actions==3.2.0",
     # Allow use of pyenv for virtual environments. To enable you need to set `VIRTUALENV_DISCOVERY=pyenv` in the shell.
     # This is useful to help tox find the correct python version when using pyenv.
-    "virtualenv-pyenv==0.4.0"
+    "virtualenv-pyenv==0.4.0",
+    # This is to have coverage available in the development environment.
+    # It's not great that it's duplicated, but I can't find a way to make it work with tox otherwise.
+    "coverage==7.3.4",
+    # Linting etc.
+    "pre-commit==3.4.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "coverage==7.3.4",
     # Linting etc.
     "pre-commit==3.4.0",
+    "black==24.1.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
This is in preparation to make `mypy` work. For `mypy` to properly work, it needs to be installed in the same environment as the module it's checking. Pre-commit usually creates separate environments for its hooks. This PR changes that and implements the same checkers with custom hooks that use the local executables. 

https://pre-commit.com/#repository-local-hooks