### PR TITLE
Parent context refactor

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,5 +4,6 @@
 **Checklist**
 <!-- For each of the following: check `[x]` if fulfilled or mark as irrelevant `[-]` if not applicable. -->
 - [ ] [CHANGELOG.md](https://github.com/tbrlpld/laces/blob/main/CHANGELOG.md) has been updated.
+- [ ] [README.md](https://github.com/tbrlpld/laces/blob/main/README.md) has been updated.
 - [ ] Checked compatibility with Wagtail.
 - [ ] Self code reviewed.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,5 @@
 **Checklist**
 <!-- For each of the following: check `[x]` if fulfilled or mark as irrelevant `[-]` if not applicable. -->
 - [ ] [CHANGELOG.md](https://github.com/tbrlpld/laces/blob/main/CHANGELOG.md) has been updated.
+- [ ] Checked compatibility with Wagtail.
 - [ ] Self code reviewed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- ...
+- Refactored handling of `parent_context` between `render_html` and `get_context_data`. This change is Wagtail-compatible. ([#24](https://github.com/tbrlpld/laces/pull/24))
 
 ### Removed
 

--- a/laces/components.py
+++ b/laces/components.py
@@ -56,7 +56,7 @@ class Component(metaclass=MediaDefiningClass):
 
     def get_context_data(
         self,
-        parent_context: "RenderContext",
+        parent_context: "Optional[RenderContext]" = None,
     ) -> "Optional[RenderContext]":
         return {}
 

--- a/laces/components.py
+++ b/laces/components.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, List
 
 from django.forms.widgets import Media, MediaDefiningClass
-from django.template import Context
 from django.template.loader import get_template
 
 from laces.typing import HasMediaProperty
@@ -45,8 +44,6 @@ class Component(metaclass=MediaDefiningClass):
         consisting of HTML should typically be returned as a
         `django.utils.safestring.SafeString` instance.
         """
-        if parent_context is None:
-            parent_context = Context()
         context_data = self.get_context_data(parent_context)
         if context_data is None:
             raise TypeError("Expected a dict from get_context_data, got None")
@@ -58,6 +55,7 @@ class Component(metaclass=MediaDefiningClass):
         self,
         parent_context: "Optional[RenderContext]" = None,
     ) -> "Optional[RenderContext]":
+        """Return the context data to render this component with."""
         return {}
 
     # fmt: off

--- a/laces/test/example/components.py
+++ b/laces/test/example/components.py
@@ -96,7 +96,7 @@ class PassesNameFromParentContextComponent(Component):
         parent_context: "Optional[RenderContext]" = None,
     ) -> "RenderContext":
         """Return the `name` from the parent context as the only key in the data."""
-        if not parent_context:
+        if not parent_context or "name" not in parent_context:
             return {}
         return {"name": parent_context["name"]}
 

--- a/laces/test/example/components.py
+++ b/laces/test/example/components.py
@@ -40,6 +40,7 @@ class PassesFixedNameToContextComponent(Component):
         self,
         parent_context: "Optional[RenderContext]" = None,
     ) -> "RenderContext":
+        """Return context data with fixed `name`."""
         return {"name": "Alice"}
 
 
@@ -54,6 +55,7 @@ class PassesInstanceAttributeToContextComponent(Component):
         self,
         parent_context: "Optional[RenderContext]" = None,
     ) -> "RenderContext":
+        """Return context data with `name` attribute."""
         return {"name": self.name}
 
 
@@ -68,6 +70,7 @@ class PassesSelfToContextComponent(Component):
         self,
         parent_context: "Optional[RenderContext]" = None,
     ) -> "RenderContext":
+        """Return context data with `self`."""
         return {"self": self}
 
 
@@ -81,13 +84,20 @@ class DataclassAsDictContextComponent(Component):
         self,
         parent_context: "Optional[RenderContext]" = None,
     ) -> "RenderContext":
+        """Return context data with dataclass object as dict."""
         return asdict(self)
 
 
 class PassesNameFromParentContextComponent(Component):
     template_name = "components/hello-name.html"
 
-    def get_context_data(self, parent_context: "RenderContext") -> "RenderContext":
+    def get_context_data(
+        self,
+        parent_context: "Optional[RenderContext]" = None,
+    ) -> "RenderContext":
+        """Return the `name` from the parent context as the only key in the data."""
+        if not parent_context:
+            return {}
         return {"name": parent_context["name"]}
 
 
@@ -103,6 +113,7 @@ class SectionWithHeadingAndParagraphComponent(Component):
         self,
         parent_context: "Optional[RenderContext]" = None,
     ) -> "RenderContext":
+        """Return context data with heading and content."""
         return {
             "heading": self.heading,
             "content": self.content,
@@ -121,6 +132,7 @@ class ListSectionComponent(Component):
         self,
         parent_context: "Optional[RenderContext]" = None,
     ) -> "RenderContext":
+        """Return context data with heading and items."""
         return {
             "heading": self.heading,
             "items": self.items,
@@ -170,6 +182,7 @@ class MediaDefiningComponent(Component):
         self,
         parent_context: "Optional[RenderContext]" = None,
     ) -> "RenderContext":
+        """Return context data with fixed `name`."""
         return {"name": "Media"}
 
     class Media:

--- a/laces/test/tests/test_components.py
+++ b/laces/test/tests/test_components.py
@@ -166,10 +166,22 @@ class TestPassesNameFromParentContextComponent(SimpleTestCase):
             "components/hello-name.html",
         )
 
-    def test_get_context_data(self) -> None:
+    def test_get_context_data_with_name_in_parent_context(self) -> None:
         self.assertEqual(
             self.component.get_context_data(parent_context={"name": "Dan"}),
             {"name": "Dan"},
+        )
+
+    def test_get_context_data_without_name_in_parent_context(self) -> None:
+        self.assertEqual(
+            self.component.get_context_data(parent_context={"notname": "Dan"}),
+            {},
+        )
+
+    def test_get_context_data_without_parent_context(self) -> None:
+        self.assertEqual(
+            self.component.get_context_data(),
+            {},
         )
 
     def test_render_html(self) -> None:

--- a/laces/tests/test_components.py
+++ b/laces/tests/test_components.py
@@ -15,7 +15,7 @@ from laces.tests.utils import MediaAssertionMixin
 
 
 if TYPE_CHECKING:
-    from typing import Any, Optional, Union
+    from typing import Optional
 
     from laces.typing import RenderContext
 
@@ -34,14 +34,28 @@ class TestComponent(MediaAssertionMixin, SimpleTestCase):
         with self.assertRaises(AttributeError):
             self.component.render_html()
 
-    def test_get_context_data_parent_context_empty_context(self) -> None:
+    def test_get_context_data_with_parent_context_empty_context(self) -> None:
         """
-        Test the default get_context_data.
+        Test the default `get_context_data`.
 
         The parent context should not matter, but we use it as it is used in
         `render_html` (which passes a `Context` object).
         """
         result = self.component.get_context_data(parent_context=Context())
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result, {})
+
+    def test_get_context_data_with_parent_context_none(self) -> None:
+        """Test the default `get_context_data` when received `parent_context=None`."""
+        result = self.component.get_context_data(parent_context=None)
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result, {})
+
+    def test_get_context_data_without_parent_context_argument(self) -> None:
+        """Test the default `get_context_data` when not passing  `parent_context`."""
+        result = self.component.get_context_data()
 
         self.assertIsInstance(result, dict)
         self.assertEqual(result, {})
@@ -125,8 +139,9 @@ class TestComponentSubclasses(MediaAssertionMixin, SimpleTestCase):
 
             def get_context_data(
                 self,
-                parent_context: "Optional[RenderContext]",
+                parent_context: "Optional[RenderContext]" = None,
             ) -> "RenderContext":
+                """Return a context dict with fixed content."""
                 return {"name": "World"}
 
         # -----------------------------------------------------------------------------
@@ -154,8 +169,9 @@ class TestComponentSubclasses(MediaAssertionMixin, SimpleTestCase):
         class ExampleComponent(Component):
             def get_context_data(
                 self,
-                parent_context: "Optional[Union[Context, dict[str, Any]]]",
+                parent_context: "Optional[RenderContext]" = None,
             ) -> None:
+                """Return `None` as the context data."""
                 return None
 
         # -----------------------------------------------------------------------------


### PR DESCRIPTION
**Description**
<!-- Describe the changes made in this pull request. -->

This PR refactors how `parent_context` is handled between the `render_html` and `get_context_data` methods. 

Previously, the `render_html` method was accepting the `parent_context` to be optional, defaulting to `None`. If the `parent_context` is `None` it is overridden to be an empty `Context` object. That context object is then used to call `get_context_data`.

Usually, the `render_html` method is called from the `component` template tag. The template tag always passes a `Context` object as the `parent_context`. It never passes `None`. 

The `get_context_data` method required a `parent_context` to be passed, it does not have a default value for the argument. But, the base implementation in `Component.get_context_data` just ignores the `parent_context` object and returns an empty dict. 

This setup has the effect that when child classes override the `get_context_data` that their
`super().get_context_data(parent_context)` call require the `parent_context` argument. But they only get an empty dict. This seems confusing and unnecessary, since we ignore the `parent_context` anyways. The only reason it's there is so that child components can make use of it.

Also, by always passing a `Context` object as the `parent_context` from `render_html` to the `get_context_data`, this suggest that this would really be a parent context, which typically includes things like the request object. However, we cannot rely on the request to be in the `parent_context` because `render_html` might have been called with `None` and just gives us an empty `Context`. 

This inconsistency between the `parent_context` that is passed to `render_html` vs the one passed to `get_context_data` could easily lead to confusion in the case where we call `render_html` directly and don't pass a `parent_context` (as opposed it being called by the `component` tag which always passes the parent context). 

This PR tries to make the `parent_context` between `render_html` and `get_context_data` more consistent. To do so, the `parent_context` argument of `get_context_data` now defaults to `None`. We still just return an empty dict. We don't override the `parent_context` in the `render_html` method anymore. 

This means that all decisions about the `parent_context` can now be made in the `get_context_data` method. This feels like the appropriate place for all handling about context data, as the method is accordingly named.

The only case where this refactor would require a change in usage (of which there is not much at this point) is when the `render_html` method is called directly without passing a parent context and `get_context_data` expects to pull some data out of the `parent_context`. This case would need to guard against the `parent_context` being `None`. 

I have checked the Wagtail code base and found no usage conflicting with this change. The Wagtail test suite also passes just fine. Therefore, I consider this change as "Wagtail-compatible", which is the only "backward-compatibility" I am concerned with at this stage. 


**Checklist**
<!-- For each of the following: check `[x]` if fulfilled or mark as irrelevant `[-]` if not applicable. -->
- [x] [CHANGELOG.md](https://github.com/tbrlpld/laces/blob/main/CHANGELOG.md) has been updated.
- [x] [README.md](https://github.com/tbrlpld/laces/blob/main/README.md) has been updated.
- [x] Checked Wagtail compatibility.
- [ ] Self code reviewed.
