### PR TITLE
WIP: Serve components view

### DIFF
--- a/laces/components.py
+++ b/laces/components.py
@@ -35,7 +35,17 @@ class Component(metaclass=MediaDefiningClass):
 
     @classmethod
     def from_request(cls: "Type[T]", request: "HttpRequest", /) -> "T":
-        """Create an instance of this component based on the given request."""
+        """
+        Create an instance of this component based on the given request.
+
+        This method is mostly an extension point to add custom logic. If a component has
+        specific access controls, this would be a good spot to check them.
+
+        By default, the request's querystring parameters are passed as keyword arguments
+        to the default initializer. No type conversion is applied. This means that the
+        initializer receives all arguments as strings. To change that behavior, override
+        this method.
+        """
         kwargs = request.GET.dict()
         return cls(**kwargs)
 

--- a/laces/components.py
+++ b/laces/components.py
@@ -8,11 +8,14 @@ from laces.typing import HasMediaProperty
 
 
 if TYPE_CHECKING:
-    from typing import Callable, Optional
+    from typing import Callable, Optional, Type, TypeVar
 
+    from django.http import HttpRequest
     from django.utils.safestring import SafeString
 
     from laces.typing import RenderContext
+
+    T = TypeVar("T", bound="Component")
 
 
 class Component(metaclass=MediaDefiningClass):
@@ -29,6 +32,11 @@ class Component(metaclass=MediaDefiningClass):
     """
 
     template_name: str
+
+    @classmethod
+    def from_request(cls: "Type[T]", request: "HttpRequest") -> "T":
+        """Create an instance of this component based on the given request."""
+        return cls()
 
     def render_html(
         self,

--- a/laces/components.py
+++ b/laces/components.py
@@ -109,7 +109,7 @@ class MediaContainer(List[HasMediaProperty]):
 _servables = {}
 
 
-def servable(name: str) -> "Callable[[type[Component]], type[Component]]":
+def register_servable(name: str) -> "Callable[[type[Component]], type[Component]]":
     def decorator(component_class: type[Component]) -> type[Component]:
         _servables[name] = component_class
         return component_class

--- a/laces/components.py
+++ b/laces/components.py
@@ -34,9 +34,10 @@ class Component(metaclass=MediaDefiningClass):
     template_name: str
 
     @classmethod
-    def from_request(cls: "Type[T]", request: "HttpRequest") -> "T":
+    def from_request(cls: "Type[T]", request: "HttpRequest", /) -> "T":
         """Create an instance of this component based on the given request."""
-        return cls()
+        kwargs = request.GET.dict()
+        return cls(**kwargs)
 
     def render_html(
         self,

--- a/laces/test/example/components.py
+++ b/laces/test/example/components.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
     from laces.typing import RenderContext
 
 
-@register_servable("renders-fixed-content-template")
 class RendersTemplateWithFixedContentComponent(Component):
     template_name = "components/hello-world.html"
 
@@ -200,3 +199,26 @@ class FooterWithMediaComponent(Component):
     class Media:
         css = {"all": ("footer.css",)}
         js = ("footer.js", "common.js")
+
+
+# Servables
+
+
+@register_servable("fixed-content-template")
+class ServableWithFixedContentTemplateComponent(Component):
+    template_name = "components/hello-world.html"
+
+
+@register_servable("with-init-args")
+class ServableWithInitilizerArgumentsComponent(Component):
+    template_name = "components/hello-name.html"
+
+    def __init__(self, name: str) -> None:
+        super().__init__()
+        self.name = name
+
+    def get_context_data(
+        self,
+        parent_context: "Optional[RenderContext]" = None,
+    ) -> "RenderContext":
+        return {"name": self.name}

--- a/laces/test/example/components.py
+++ b/laces/test/example/components.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from django.utils.html import format_html
 
-from laces.components import Component, servable
+from laces.components import Component, register_servable
 
 
 if TYPE_CHECKING:
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from laces.typing import RenderContext
 
 
-@servable("renders-fixed-content-template")
+@register_servable("renders-fixed-content-template")
 class RendersTemplateWithFixedContentComponent(Component):
     template_name = "components/hello-world.html"
 

--- a/laces/test/example/components.py
+++ b/laces/test/example/components.py
@@ -228,3 +228,13 @@ class ServableWithInitilizerArgumentsComponent(Component):
 class ServableIntAdderComponent(Component):
     def __init__(self, number: int) -> None:
         self.number = 0 + number
+
+
+class CustomException(Exception):
+    pass
+
+
+@register_servable("with-custom-exception-init")
+class ServableWithCustomExceptionInitializerComponent(Component):
+    def __init__(self) -> None:
+        raise CustomException

--- a/laces/test/example/components.py
+++ b/laces/test/example/components.py
@@ -222,3 +222,9 @@ class ServableWithInitilizerArgumentsComponent(Component):
         parent_context: "Optional[RenderContext]" = None,
     ) -> "RenderContext":
         return {"name": self.name}
+
+
+@register_servable("int-adder")
+class ServableIntAdderComponent(Component):
+    def __init__(self, number: int) -> None:
+        self.number = 0 + number

--- a/laces/test/example/components.py
+++ b/laces/test/example/components.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from django.utils.html import format_html
 
-from laces.components import Component
+from laces.components import Component, servable
 
 
 if TYPE_CHECKING:
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from laces.typing import RenderContext
 
 
+@servable("renders-fixed-content-template")
 class RendersTemplateWithFixedContentComponent(Component):
     template_name = "components/hello-world.html"
 

--- a/laces/test/tests/test_views.py
+++ b/laces/test/tests/test_views.py
@@ -159,3 +159,8 @@ class TestServeComponent(TestCase):
         response = self.client.get("/components/with-init-args/")
 
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    def test_get_component_with_non_string_argument(self) -> None:
+        response = self.client.get("/components/int-adder/?number=2")
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)

--- a/laces/test/tests/test_views.py
+++ b/laces/test/tests/test_views.py
@@ -143,3 +143,19 @@ class TestServeComponent(TestCase):
             response.content.decode("utf-8"),
             "<h1>Hello Bob</h1>",
         )
+
+    def test_get_component_with_init_args_and_name_and_extra_parameter(self) -> None:
+        response = self.client.get(
+            "/components/with-init-args/?name=Bob&extra=notexpected"
+        )
+
+        # You could argue that we should ignore the extra parameters. But, this seems
+        # like it would create inconsistent behavior between having too many and too few
+        # arguments. It's probably cleaner to just response the same and require the
+        # request to be fixed.
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    def test_get_component_with_init_args_and_no_parameters(self) -> None:
+        response = self.client.get("/components/with-init-args/")
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)

--- a/laces/test/tests/test_views.py
+++ b/laces/test/tests/test_views.py
@@ -120,3 +120,8 @@ class TestServeComponent(TestCase):
             response.content.decode("utf-8"),
             "<h1>Hello World</h1>",
         )
+
+    def test_get_not_registered_component(self) -> None:
+        response = self.client.get("/components/not-a-component/")
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)

--- a/laces/test/tests/test_views.py
+++ b/laces/test/tests/test_views.py
@@ -164,3 +164,8 @@ class TestServeComponent(TestCase):
         response = self.client.get("/components/int-adder/?number=2")
 
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    def test_get_component_with_custom_exception(self) -> None:
+        response = self.client.get("/components/with-custom-exception-init/")
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)

--- a/laces/test/tests/test_views.py
+++ b/laces/test/tests/test_views.py
@@ -112,8 +112,8 @@ class TestServeComponent(TestCase):
     """
 
     def test_get_component(self) -> None:
-        # Requesting the `laces.test.example.components.RendersTemplateWithFixedContentComponent`
-        response = self.client.get("/components/renders-fixed-content-template/")
+        # Requesting the `laces.test.example.components.ServableWithWithFixedContentTemplateComponent`
+        response = self.client.get("/components/fixed-content-template/")
 
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertHTMLEqual(
@@ -125,3 +125,21 @@ class TestServeComponent(TestCase):
         response = self.client.get("/components/not-a-component/")
 
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_get_component_with_init_args_and_name_alice(self) -> None:
+        response = self.client.get("/components/with-init-args/?name=Alice")
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertHTMLEqual(
+            response.content.decode("utf-8"),
+            "<h1>Hello Alice</h1>",
+        )
+
+    def test_get_component_with_init_args_and_name_bob(self) -> None:
+        response = self.client.get("/components/with-init-args/?name=Bob")
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertHTMLEqual(
+            response.content.decode("utf-8"),
+            "<h1>Hello Bob</h1>",
+        )

--- a/laces/test/tests/test_views.py
+++ b/laces/test/tests/test_views.py
@@ -97,3 +97,26 @@ class TestKitchenSink(TestCase):
             response_html,
             count=1,
         )
+
+
+class TestServeComponent(TestCase):
+    """
+    Test the serve view from the perspective of an external project.
+
+    The functionality is not defined in this project. It's in Laces, but I want to have
+    some use cases of how this maybe be used.
+
+    This makes some assumptions about what is set up in the project. There will need to
+    be other more encapsulated tests in Laces directly.
+
+    """
+
+    def test_get_component(self) -> None:
+        # Requesting the `laces.test.example.components.RendersTemplateWithFixedContentComponent`
+        response = self.client.get("/components/renders-fixed-content-template/")
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertHTMLEqual(
+            response.content.decode("utf-8"),
+            "<h1>Hello World</h1>",
+        )

--- a/laces/test/urls.py
+++ b/laces/test/urls.py
@@ -1,8 +1,9 @@
-from django.urls import path
+from django.urls import include, path
 
 from laces.test.example.views import kitchen_sink
 
 
 urlpatterns = [
     path("", kitchen_sink),
+    path("components/", include("laces.urls")),
 ]

--- a/laces/tests/test_components.py
+++ b/laces/tests/test_components.py
@@ -106,6 +106,64 @@ class TestComponentSubclasses(MediaAssertionMixin, SimpleTestCase):
 
         self.assertIsInstance(result, ExampleComponent)
 
+    def test_from_request_with_component_w_name_arg_request_wo_name_para(self) -> None:
+        # -----------------------------------------------------------------------------
+        class ExampleComponent(Component):
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+        # -----------------------------------------------------------------------------
+        request = self.request_factory.get("")
+
+        with self.assertRaises(TypeError) as ctx:
+            ExampleComponent.from_request(request)
+
+        self.assertIn("required positional argument", str(ctx.exception))
+
+    def test_from_request_with_component_w_name_arg_request_w_name_para(self) -> None:
+        # -----------------------------------------------------------------------------
+        class ExampleComponent(Component):
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+        # -----------------------------------------------------------------------------
+        request = self.request_factory.get("", data={"name": "Alice"})
+
+        result = ExampleComponent.from_request(request)
+
+        self.assertEqual(result.name, "Alice")
+
+    def test_from_request_with_component_w_name_arg_request_w_extra_para(self) -> None:
+        # -----------------------------------------------------------------------------
+        class ExampleComponent(Component):
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+        # -----------------------------------------------------------------------------
+        request = self.request_factory.get("", data={"name": "Alice", "other": "Bob"})
+
+        with self.assertRaises(TypeError) as ctx:
+            ExampleComponent.from_request(request)
+
+        self.assertIn("unexpected keyword argument", str(ctx.exception))
+
+    def test_from_request_with_component_init_raises_custom_exception(self) -> None:
+        # -----------------------------------------------------------------------------
+        class CustomException(Exception):
+            pass
+
+        class ExampleComponent(Component):
+            def __init__(self) -> None:
+                raise CustomException
+
+        # -----------------------------------------------------------------------------
+        request = self.request_factory.get("")
+
+        # No special handling happens in the `from_request` method by default.
+        # The raised exception should be exposed.
+        with self.assertRaises(CustomException):
+            ExampleComponent.from_request(request)
+
     def test_render_html_with_template_name_set(self) -> None:
         """
         Test `render_html` method with a set `template_name` attribute.

--- a/laces/tests/test_components.py
+++ b/laces/tests/test_components.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from django.conf import settings
 from django.forms import widgets
 from django.template import Context
-from django.test import SimpleTestCase
+from django.test import RequestFactory, SimpleTestCase
 from django.utils.safestring import SafeString
 
 from laces.components import Component, MediaContainer
@@ -88,9 +88,23 @@ class TestComponentSubclasses(MediaAssertionMixin, SimpleTestCase):
         # Write content to the template file to ensure it exists.
         self.set_example_template_content("")
 
+        self.request_factory = RequestFactory()
+
     def set_example_template_content(self, content: str) -> None:
         with open(self.example_template, "w") as f:
             f.write(content)
+
+    def test_from_request_with_component_wo_init_args(self) -> None:
+        # -----------------------------------------------------------------------------
+        class ExampleComponent(Component):
+            pass
+
+        # -----------------------------------------------------------------------------
+        request = self.request_factory.get("")
+
+        result = ExampleComponent.from_request(request)
+
+        self.assertIsInstance(result, ExampleComponent)
 
     def test_render_html_with_template_name_set(self) -> None:
         """

--- a/laces/urls.py
+++ b/laces/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from laces.views import serve
+
+
+app_name = "laces"
+
+
+urlpatterns = [path("<slug:component_slug>/", serve, name="serve")]

--- a/laces/views.py
+++ b/laces/views.py
@@ -2,7 +2,9 @@ import logging
 
 from typing import TYPE_CHECKING
 
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
+
+from laces.components import ServableComponentNotFound, get_servable
 
 
 if TYPE_CHECKING:
@@ -13,4 +15,12 @@ logger = logging.getLogger(__name__)
 
 def serve(request: "HttpRequest", component_slug: str) -> HttpResponse:
     logger.error(component_slug)
-    return HttpResponse()
+
+    try:
+        Component = get_servable(component_slug)
+    except ServableComponentNotFound:
+        raise Http404
+
+    component = Component()
+
+    return HttpResponse(content=component.render_html())

--- a/laces/views.py
+++ b/laces/views.py
@@ -22,10 +22,8 @@ def serve(request: "HttpRequest", component_slug: str) -> HttpResponse:
     except ServableComponentNotFound:
         raise Http404
 
-    kwargs = request.GET.dict()
-
     try:
-        component = Component(**kwargs)
+        component = Component.from_request(request)
     except Exception as e:
         raise BadRequest(e)
 

--- a/laces/views.py
+++ b/laces/views.py
@@ -21,6 +21,7 @@ def serve(request: "HttpRequest", component_slug: str) -> HttpResponse:
     except ServableComponentNotFound:
         raise Http404
 
-    component = Component()
+    kwargs = request.GET.dict()
+    component = Component(**kwargs)
 
     return HttpResponse(content=component.render_html())

--- a/laces/views.py
+++ b/laces/views.py
@@ -1,0 +1,16 @@
+import logging
+
+from typing import TYPE_CHECKING
+
+from django.http import HttpResponse
+
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
+
+logger = logging.getLogger(__name__)
+
+
+def serve(request: "HttpRequest", component_slug: str) -> HttpResponse:
+    logger.error(component_slug)
+    return HttpResponse()

--- a/laces/views.py
+++ b/laces/views.py
@@ -26,7 +26,7 @@ def serve(request: "HttpRequest", component_slug: str) -> HttpResponse:
 
     try:
         component = Component(**kwargs)
-    except TypeError as e:
+    except Exception as e:
         raise BadRequest(e)
 
     return HttpResponse(content=component.render_html())

--- a/laces/views.py
+++ b/laces/views.py
@@ -2,6 +2,7 @@ import logging
 
 from typing import TYPE_CHECKING
 
+from django.core.exceptions import BadRequest
 from django.http import Http404, HttpResponse
 
 from laces.components import ServableComponentNotFound, get_servable
@@ -22,6 +23,10 @@ def serve(request: "HttpRequest", component_slug: str) -> HttpResponse:
         raise Http404
 
     kwargs = request.GET.dict()
-    component = Component(**kwargs)
+
+    try:
+        component = Component(**kwargs)
+    except TypeError as e:
+        raise BadRequest(e)
 
     return HttpResponse(content=component.render_html())


### PR DESCRIPTION
**Description**
<!-- Describe the changes made in this pull request. -->

Serve components directly. This should be super interesting when combined with HTMX. 


**Todo**
- [ ] Check servable components that are defined in a module that is not imported anywhere. I am assuming that these will not be registered yet. There would need to be some process to find them.  

**Checklist**
<!-- For each of the following: check `[x]` if fulfilled or mark as irrelevant `[-]` if not applicable. -->
- [ ] [CHANGELOG.md](https://github.com/tbrlpld/laces/blob/main/CHANGELOG.md) has been updated.
- [ ] Self code reviewed.
