### PR TITLE
Remove context `None` guard exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- ...
+- The `TypeError` that was raised in `render_html` when `get_context_data` returned `None` was removed. This change is Wagtail-compatible. ([#30](https://github.com/tbrlpld/laces/pull/30))
 
 ## [0.1.1] - 2024-02-10
 

--- a/laces/components.py
+++ b/laces/components.py
@@ -45,9 +45,6 @@ class Component(metaclass=MediaDefiningClass):
         `django.utils.safestring.SafeString` instance.
         """
         context_data = self.get_context_data(parent_context)
-        # if context_data is None:
-        #     raise TypeError("Expected a dict from get_context_data, got None")
-
         template = get_template(self.template_name)
         return template.render(context_data)
 

--- a/laces/components.py
+++ b/laces/components.py
@@ -45,8 +45,8 @@ class Component(metaclass=MediaDefiningClass):
         `django.utils.safestring.SafeString` instance.
         """
         context_data = self.get_context_data(parent_context)
-        if context_data is None:
-            raise TypeError("Expected a dict from get_context_data, got None")
+        # if context_data is None:
+        #     raise TypeError("Expected a dict from get_context_data, got None")
 
         template = get_template(self.template_name)
         return template.render(context_data)

--- a/laces/tests/test_components.py
+++ b/laces/tests/test_components.py
@@ -152,16 +152,18 @@ class TestComponentSubclasses(MediaAssertionMixin, SimpleTestCase):
 
         self.assertEqual(result, "Hello World")
 
-    def test_render_html_when_get_context_data_returns_None(self) -> None:
+    def test_render_html_when_get_context_data_returns_none(self) -> None:
         """
         Test `render_html` method when `get_context_data` returns `None`.
 
         Originally, the `render_html` method explicitly raised a `TypeError` when
         `None` was returned from `get_context_method`.
 
-        I was not able to find out why this check was put in place. The components usage
-        in Wagtail does not reveal any issues when the error is removed. Also, the
-        following template rendering works just fine with the context being `None`.
+        I was not able to find out why this check was put in place. The usage of
+        components in Wagtail does not reveal any issues when the raising of the
+        exception is removed. Also, the following template rendering (with
+        `django.template.base.Template.render`) works just fine with the context being
+        `None`.
 
         It seems therefore safe to assume that this was a left-over without much current
         need.


### PR DESCRIPTION
**Description**

This PR removes a conditional in the `render_html` method that raised an exception when value returned from `get_context_data` is `None`. 

I tried to find out why this was in place, but was not successful. 
My assumption is that this is a left over from a previous implementation in Wagtail. 

Returning `None` from `get_context_data` has no negative side effects. 
The return value from `get_context_data` is passed to [`django.template.base.Template.render`](https://github.com/django/django/blob/main/django/template/base.py#L165). 
This method handles receiving `None` just fine. 
It only means that the template won't have any context data. 
This may or may not be expected.

I can't really find a reason for this exceptions to be raised. 
In particular, if `None` would cause a downstream exception, we would still just have another exception. 
So it's not clear what was gained by raising this `TypeError`. 

So, to simplify the render method, the exception is now removed. 
I have run the Wagtail test suite with this change and not found any error because of it. 
Therefore, it seems safe to remove the conditional. 

**Checklist**
<!-- For each of the following: check `[x]` if fulfilled or mark as irrelevant `[-]` if not applicable. -->
- [x] [CHANGELOG.md](https://github.com/tbrlpld/laces/blob/main/CHANGELOG.md) has been updated.
- [x] [README.md](https://github.com/tbrlpld/laces/blob/main/README.md) has been updated.
- [x] Checked compatibility with Wagtail.
- [x] Self code reviewed.
